### PR TITLE
Parse the whole include context

### DIFF
--- a/Backend/ForTea.Core/Parsing/T4Parser.cs
+++ b/Backend/ForTea.Core/Parsing/T4Parser.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using GammaJul.ForTea.Core.Parser;
+using GammaJul.ForTea.Core.Parsing.Ranges;
 using GammaJul.ForTea.Core.Psi;
 using GammaJul.ForTea.Core.Tree.Impl;
 using JetBrains.Annotations;
@@ -40,6 +41,7 @@ namespace GammaJul.ForTea.Core.Parsing
 		public override TreeElement ParseFile()
 		{
 			var result = ParseFileWithoutCleanup();
+			result.SetSourceFile(SourceFile);
 			T4ParsingContextHelper.Reset();
 			return result;
 		}

--- a/Backend/ForTea.Core/Psi/Service/T4LanguageService.cs
+++ b/Backend/ForTea.Core/Psi/Service/T4LanguageService.cs
@@ -1,6 +1,9 @@
 using System.Collections.Generic;
 using GammaJul.ForTea.Core.Parsing;
+using GammaJul.ForTea.Core.Psi.Invalidation;
 using JetBrains.Annotations;
+using JetBrains.Diagnostics;
+using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.ExtensionsAPI.Caches2;
 using JetBrains.ReSharper.Psi.Impl;
@@ -14,6 +17,9 @@ namespace GammaJul.ForTea.Core.Psi.Service {
 	/// <summary>Base, file independent language service for T4.</summary>
 	[Language(typeof(T4Language))]
 	public sealed class T4LanguageService : LanguageService {
+		[NotNull]
+		private ILogger Logger { get; }
+
 		/// <summary>Creates a lexer that filters tokens that have no meaning.</summary>
 		/// <param name="lexer">The base lexer.</param>
 		/// <returns>An implementation of a filtering lexer.</returns>
@@ -30,8 +36,26 @@ namespace GammaJul.ForTea.Core.Psi.Service {
 		/// <param name="module">The module owning the source file.</param>
 		/// <param name="sourceFile">The source file.</param>
 		/// <returns>A T4 parser that operates onto <paramref name="lexer"/>.</returns>
-		public override IParser CreateParser(ILexer lexer, IPsiModule module, IPsiSourceFile sourceFile) =>
-			new T4Parser(lexer, sourceFile);
+		/// <note>
+		/// For the sake of providing the most complete intelligent support,
+		/// we make the widest possible context part of the primary PSI.
+		/// </note>
+		[NotNull]
+		public override IParser CreateParser(ILexer lexer, IPsiModule module, IPsiSourceFile sourceFile)
+		{
+			if (sourceFile == null)
+			{
+				Logger.Warn("Creating parser for null sourceFile");
+				return new T4Parser(lexer, null);
+			}
+
+			var projectFile = sourceFile.ToProjectFile();
+			var solution = sourceFile.GetSolution();
+			var graph = solution.GetComponent<IT4FileDependencyGraph>();
+			var rootSourceFile = graph.FindBestRoot(projectFile).ToSourceFile().NotNull();
+			var rootLexer = GetPrimaryLexerFactory().CreateLexer(rootSourceFile.Document.Buffer);
+			return new T4Parser(rootLexer, rootSourceFile);
+		}
 
 		/// <summary>
 		/// Gets a cache provider for T4 files.
@@ -53,16 +77,11 @@ namespace GammaJul.ForTea.Core.Psi.Service {
 		public override IEnumerable<ITypeDeclaration> FindTypeDeclarations(IFile file)
 			=> EmptyList<ITypeDeclaration>.InstanceList;
 
-		/// <summary>Initializes a new instance of the <see cref="T4LanguageService"/> class.</summary>
-		/// <param name="t4Language">The T4 language.</param>
-		/// <param name="constantValueService">The constant value service.</param>
 		public T4LanguageService(
 			[NotNull] T4Language t4Language,
-			[NotNull] IConstantValueService constantValueService
-		) : base(t4Language, constantValueService)
-		{
-		}
-
+			[NotNull] IConstantValueService constantValueService,
+			[NotNull] ILogger logger
+		) : base(t4Language, constantValueService) => Logger = logger;
 	}
 
 }

--- a/Backend/ForTea.Core/TemplateProcessing/CodeGeneration/Generators/T4CSharpCodeBehindGenerator.cs
+++ b/Backend/ForTea.Core/TemplateProcessing/CodeGeneration/Generators/T4CSharpCodeBehindGenerator.cs
@@ -1,13 +1,8 @@
-using GammaJul.ForTea.Core.Parsing;
-using GammaJul.ForTea.Core.Psi;
-using GammaJul.ForTea.Core.Psi.Invalidation;
 using GammaJul.ForTea.Core.TemplateProcessing.CodeCollecting;
 using GammaJul.ForTea.Core.TemplateProcessing.CodeGeneration.Converters;
 using GammaJul.ForTea.Core.Tree;
 using JetBrains.Annotations;
-using JetBrains.Diagnostics;
 using JetBrains.ProjectModel;
-using JetBrains.ReSharper.Psi;
 
 namespace GammaJul.ForTea.Core.TemplateProcessing.CodeGeneration.Generators
 {
@@ -23,70 +18,16 @@ namespace GammaJul.ForTea.Core.TemplateProcessing.CodeGeneration.Generators
 		[NotNull]
 		private ISolution Solution { get; }
 
-		[NotNull]
-		private IT4FileDependencyGraph Graph { get; }
-
 		public T4CSharpCodeBehindGenerator(
 			[NotNull] IT4File actualFile,
 			[NotNull] ISolution solution
-		) : base(actualFile)
-		{
-			Solution = solution;
-			Graph = solution.GetComponent<IT4FileDependencyGraph>();
-		}
+		) : base(actualFile) => Solution = solution;
 
 		protected override T4CSharpCodeGenerationInfoCollectorBase Collector =>
-			new T4CSharpCodeBehindGenerationInfoCollector(Root, Solution);
+			new T4CSharpCodeBehindGenerationInfoCollector(File, Solution);
 
 		protected override T4CSharpIntermediateConverterBase CreateConverter(
 			T4CSharpCodeGenerationIntermediateResult intermediateResult
-		) => new T4CSharpCodeBehindIntermediateConverter(intermediateResult, ActualFile);
-
-		/// <summary>
-		/// In generated code-behind, we use root file to provide intelligent support for indirectly included files,
-		/// i.e. files that are included alongside with the current file into somewhere else.
-		/// </summary>
-		[NotNull]
-		private IT4File Root
-		{
-			get
-			{
-				var projectFile = ActualFile.GetSourceFile().ToProjectFile().NotNull();
-				var rootPsiSourceFile = Graph.FindBestRoot(projectFile).ToSourceFile();
-				// Since primary and secondary PSI files are built simultaneously,
-				// by this moment the primary PSI has not yet been registered in caches.
-				// Therefore requesting it would cause
-				// constructing a brand new primary and secondary PSI,
-				// leading to StackOverflowExceptions.
-				// This is why this corner case has to be dealt with separately.
-				if (ActualFile.GetSourceFile() == rootPsiSourceFile) return ActualFile;
-				// It is NOT safe to assume that PSI for the root file can be built
-				// The primary PSI only relies on source files.
-				// The secondary PSI only relies on the primary PSI of
-				// either the current file, or a file that includes it.
-				// In most cases it means that PSI construction
-				// is well-ordered and we would be able to call rootPsiSourceFile.GetPrimaryPsi,
-				// except for the edge case of recursion in includes,
-				// which would cause StackOverflowExceptions
-				// TODO: somehow deal with that edge case and avoid building a new tree
-				return BuildT4Tree(rootPsiSourceFile.NotNull());
-			}
-		}
-
-		/// <note>
-		/// This method builds PSI from scratch,
-		/// which might cause creepy StackOverflowExceptions,
-		/// difficult-to-catch bugs and performance issues!
-		/// Use it VERY carefully!
-		/// </note>
-		[NotNull]
-		private static IT4File BuildT4Tree([NotNull] IPsiSourceFile target)
-		{
-			var languageService = T4Language.Instance.LanguageService().NotNull();
-			var lexer = languageService.GetPrimaryLexerFactory().CreateLexer(target.Document.Buffer);
-			var file = (IT4File) new T4Parser(lexer, target).ParseFile();
-			file.SetSourceFile(target);
-			return file;
-		}
+		) => new T4CSharpCodeBehindIntermediateConverter(intermediateResult, File);
 	}
 }

--- a/Backend/ForTea.Core/TemplateProcessing/CodeGeneration/Generators/T4CSharpCodeGeneratorBase.cs
+++ b/Backend/ForTea.Core/TemplateProcessing/CodeGeneration/Generators/T4CSharpCodeGeneratorBase.cs
@@ -12,12 +12,12 @@ namespace GammaJul.ForTea.Core.TemplateProcessing.CodeGeneration.Generators
 		private const string DefaultErrorMessage = "ErrorGeneratingOutput";
 
 		[NotNull]
-		protected IT4File ActualFile { get; }
+		protected virtual IT4File File { get; }
 
 		/// <summary>Initializes a new instance of the <see cref="T4CSharpCodeGeneratorBase"/> class.</summary>
 		/// <param name="actualFile">The associated T4 file whose C# code behind will be generated.</param>
 		protected T4CSharpCodeGeneratorBase([NotNull] IT4File actualFile) =>
-			ActualFile = actualFile ?? throw new ArgumentNullException(nameof(actualFile));
+			File = actualFile ?? throw new ArgumentNullException(nameof(actualFile));
 
 		[NotNull]
 		public T4CSharpCodeGenerationResult Generate() =>
@@ -32,7 +32,7 @@ namespace GammaJul.ForTea.Core.TemplateProcessing.CodeGeneration.Generators
 			}
 			catch (T4OutputGenerationException)
 			{
-				var result = new T4CSharpCodeGenerationResult(ActualFile);
+				var result = new T4CSharpCodeGenerationResult(File);
 				result.Append(DefaultErrorMessage);
 				return result;
 			}


### PR DESCRIPTION
Prior to this, many features (including the code-behind generator) had to parse T4 file manually (by creating and running a new lexer/parser). That made it impossible to implement proper navigation to the symbols defined in the indirect include context. That could also create significant memory traffic and lead to performance issues, although that was not significant enough to be visible