### PR TITLE
Use the most suitable target framework id in T4 psi modules

### DIFF
--- a/Backend/ForTea.Core/Psi/Modules/T4FilePsiModule.cs
+++ b/Backend/ForTea.Core/Psi/Modules/T4FilePsiModule.cs
@@ -77,7 +77,8 @@ namespace GammaJul.ForTea.Core.Psi.Modules
 			[NotNull] IProjectFile projectFile,
 			[NotNull] ChangeManager changeManager,
 			[NotNull] IShellLocks shellLocks,
-			[NotNull] IT4Environment t4Environment
+			[NotNull] IT4Environment t4Environment,
+			[CanBeNull] TargetFrameworkId primaryTargetFrameworkId
 		)
 		{
 			Lifetime = lifetime;
@@ -89,7 +90,7 @@ namespace GammaJul.ForTea.Core.Psi.Modules
 			ChangeManager = changeManager;
 			ShellLocks = shellLocks;
 			ChangeProvider = new FakeChangeProvider();
-			TargetFrameworkId = ProjectFile.SelectTargetFrameworkId(t4Environment);
+			TargetFrameworkId = t4Environment.SelectTargetFrameworkId(primaryTargetFrameworkId);
 			Project = ProjectFile.GetProject().NotNull();
 			var resolveContext = Project.IsMiscFilesProject()
 				? UniversalModuleReferenceContext.Instance
@@ -108,7 +109,7 @@ namespace GammaJul.ForTea.Core.Psi.Modules
 			changeManager.RegisterChangeProvider(lifetime, ChangeProvider);
 			changeManager.AddDependency(lifetime, PsiModules, ChangeProvider);
 			Solution.GetComponent<T4DeclaredAssembliesManager>().FileDataChanged.Advise(lifetime, OnFileDataChanged);
-			PersistentId = BuildPersistentId();
+			PersistentId = BuildPersistentId(primaryTargetFrameworkId);
 			ChangeManager.ExecuteAfterChange(() =>
 			{
 				AssemblyReferenceManager.AddBaseReferences();
@@ -117,7 +118,8 @@ namespace GammaJul.ForTea.Core.Psi.Modules
 		}
 
 		[NotNull]
-		private string BuildPersistentId() => Prefix + ProjectFile.GetPersistentID();
+		private string BuildPersistentId([CanBeNull] TargetFrameworkId primaryTargetFrameworkId) =>
+			$"{Prefix}(path: {ProjectFile.GetPersistentID()}, containing project target framework id: {primaryTargetFrameworkId?.UniqueString ?? "null"})";
 
 		private void OnFileDataChanged(Pair<IPsiSourceFile, T4DeclaredAssembliesDiff> pair)
 		{

--- a/Backend/ForTea.Core/Psi/Modules/T4FilePsiModule.cs
+++ b/Backend/ForTea.Core/Psi/Modules/T4FilePsiModule.cs
@@ -90,11 +90,12 @@ namespace GammaJul.ForTea.Core.Psi.Modules
 			ChangeManager = changeManager;
 			ShellLocks = shellLocks;
 			ChangeProvider = new FakeChangeProvider();
-			TargetFrameworkId = t4Environment.SelectTargetFrameworkId(primaryTargetFrameworkId);
+			TargetFrameworkId = t4Environment.SelectTargetFrameworkId(primaryTargetFrameworkId, projectFile);
 			Project = ProjectFile.GetProject().NotNull();
 			var resolveContext = Project.IsMiscFilesProject()
 				? UniversalModuleReferenceContext.Instance
 				: this.GetResolveContextEx(ProjectFile);
+			Assertion.Assert(resolveContext.TargetFramework == TargetFrameworkId, "Failed to select TargetFrameworkId");
 			var documentManager = Solution.GetComponent<DocumentManager>();
 			SourceFile = CreateSourceFile(ProjectFile, documentManager, resolveContext);
 			AssemblyReferenceManager = new T4AssemblyReferenceManager(

--- a/Backend/ForTea.Core/Psi/Modules/T4ModulePsiUtils.cs
+++ b/Backend/ForTea.Core/Psi/Modules/T4ModulePsiUtils.cs
@@ -19,9 +19,12 @@ namespace GammaJul.ForTea.Core.Psi.Modules
 		[NotNull]
 		public static TargetFrameworkId SelectTargetFrameworkId(
 			[NotNull] this IT4Environment t4Environment,
-			[CanBeNull] TargetFrameworkId candidate
+			[CanBeNull] TargetFrameworkId candidate,
+			[NotNull] IProjectFile file
 		)
 		{
+			var project = file.GetProject();
+			if (project?.IsMiscFilesProject() != false) return UniversalModuleReferenceContext.Instance.TargetFramework;
 			// Generated C# code contains references to CodeDom, and thus can only be compiled by classical .NET
 			// TODO: generate code without CodeDom in .NET Core projects
 			if (candidate != null && candidate.IsNetFramework) return candidate;

--- a/Backend/ForTea.Core/Psi/Modules/T4ModulePsiUtils.cs
+++ b/Backend/ForTea.Core/Psi/Modules/T4ModulePsiUtils.cs
@@ -18,16 +18,13 @@ namespace GammaJul.ForTea.Core.Psi.Modules
 
 		[NotNull]
 		public static TargetFrameworkId SelectTargetFrameworkId(
-			[NotNull] this IProjectFile file,
-			[NotNull] IT4Environment t4Environment
+			[NotNull] this IT4Environment t4Environment,
+			[CanBeNull] TargetFrameworkId candidate
 		)
 		{
-			var project = file.GetProject();
-			if (project?.IsMiscFilesProject() != false) return UniversalModuleReferenceContext.Instance.TargetFramework;
-			var containingTargetFrameworkId = project.GetResolveContext().TargetFramework;
 			// Generated C# code contains references to CodeDom, and thus can only be compiled by classical .NET
 			// TODO: generate code without CodeDom in .NET Core projects
-			if (containingTargetFrameworkId.IsNetFramework) return containingTargetFrameworkId;
+			if (candidate != null && candidate.IsNetFramework) return candidate;
 			return t4Environment.TargetFrameworkId;
 		}
 	}

--- a/Backend/ForTea.Core/Psi/Modules/T4ProjectPsiModuleHandler.cs
+++ b/Backend/ForTea.Core/Psi/Modules/T4ProjectPsiModuleHandler.cs
@@ -58,7 +58,8 @@ namespace GammaJul.ForTea.Core.Psi.Modules
 				project.Locks,
 				changeManager,
 				t4Environment,
-				templateKindProvider
+				templateKindProvider,
+				handler.PrimaryModule?.TargetFrameworkId
 			);
 		}
 

--- a/Backend/ForTea.Core/Psi/Modules/T4PsiModuleProvider.cs
+++ b/Backend/ForTea.Core/Psi/Modules/T4PsiModuleProvider.cs
@@ -13,6 +13,7 @@ using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Modules;
 using JetBrains.ReSharper.Resources.Shell;
 using JetBrains.Util;
+using JetBrains.Util.Dotnet.TargetFrameworkIds;
 
 namespace GammaJul.ForTea.Core.Psi.Modules {
 
@@ -30,6 +31,9 @@ namespace GammaJul.ForTea.Core.Psi.Modules {
 
 		[NotNull]
 		private IT4TemplateKindProvider TemplateDataManager { get; }
+
+		[CanBeNull]
+		private TargetFrameworkId PrimaryTargetFrameworkId { get; }
 
 		private readonly struct ModuleWrapper {
 
@@ -171,7 +175,8 @@ namespace GammaJul.ForTea.Core.Psi.Modules {
 				projectFile,
 				_changeManager,
 				_shellLocks,
-				_t4Environment
+				_t4Environment,
+				PrimaryTargetFrameworkId
 			);
 			_modules[projectFile] = new ModuleWrapper(psiModule, lifetimeDefinition);
 			changeBuilder.AddModuleChange(psiModule, PsiModuleChange.ChangeType.Added);
@@ -210,7 +215,8 @@ namespace GammaJul.ForTea.Core.Psi.Modules {
 			[NotNull] IShellLocks shellLocks,
 			[NotNull] ChangeManager changeManager,
 			[NotNull] IT4Environment t4Environment,
-			[NotNull] IT4TemplateKindProvider templateDataManager
+			[NotNull] IT4TemplateKindProvider templateDataManager,
+			[CanBeNull] TargetFrameworkId primaryTargetFrameworkId = null
 		)
 		{
 			_lifetime = lifetime;
@@ -218,6 +224,7 @@ namespace GammaJul.ForTea.Core.Psi.Modules {
 			_changeManager = changeManager;
 			_t4Environment = t4Environment;
 			TemplateDataManager = templateDataManager;
+			PrimaryTargetFrameworkId = primaryTargetFrameworkId;
 		}
 
 	}

--- a/Backend/ForTea.RiderPlugin/T4RiderEnvironment.cs
+++ b/Backend/ForTea.RiderPlugin/T4RiderEnvironment.cs
@@ -1,8 +1,7 @@
-using System;
 using System.Collections.Generic;
+using System.Linq;
 using GammaJul.ForTea.Core.Impl;
 using JetBrains.Application;
-using JetBrains.Application.platforms;
 using JetBrains.ReSharper.Psi.CSharp;
 using JetBrains.Util.Dotnet.TargetFrameworkIds;
 using Microsoft.VisualStudio.TextTemplating;
@@ -12,8 +11,8 @@ namespace JetBrains.ForTea.RiderPlugin
 	[ShellComponent]
 	public sealed class T4RiderEnvironment : T4DefaultEnvironment
 	{
-		public override TargetFrameworkId TargetFrameworkId { get; } =
-			TargetFrameworkId.Create(FrameworkIdentifier.NetFramework, new Version(4, 7, 2));
+		public override TargetFrameworkId TargetFrameworkId =>
+			TargetFrameworkId.AllKnownIds.Where(id => id.IsNetFramework).Max();
 
 		public override CSharpLanguageLevel CSharpLanguageLevel => CSharpLanguageLevel.Latest;
 


### PR DESCRIPTION
The plugin used to create 'duplicate' PSI modules when the containing project had more than one target framework. Let's use TargetFrameworkId of the containing project psi module to distinguish the created PSI files.
This PR fixes https://youtrack.jetbrains.com/issue/RIDER-33235