### PR TITLE
Optimize the include cache

### DIFF
--- a/Backend/ForTea.Core/Psi/Cache/IT4FileDependencyGraph.cs
+++ b/Backend/ForTea.Core/Psi/Cache/IT4FileDependencyGraph.cs
@@ -1,5 +1,5 @@
 using JetBrains.Annotations;
-using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Psi;
 
 namespace GammaJul.ForTea.Core.Psi.Cache
 {
@@ -14,6 +14,6 @@ namespace GammaJul.ForTea.Core.Psi.Cache
 		/// </summary>
 		/// TODO: cache root?
 		[NotNull]
-		IProjectFile FindBestRoot([NotNull] IProjectFile file);
+		IPsiSourceFile FindBestRoot([NotNull] IPsiSourceFile file);
 	}
 }

--- a/Backend/ForTea.Core/Psi/Cache/IT4FileGraphNotifier.cs
+++ b/Backend/ForTea.Core/Psi/Cache/IT4FileGraphNotifier.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Collections.Generic;
-using JetBrains.Util;
+using JetBrains.ReSharper.Psi;
 
 namespace GammaJul.ForTea.Core.Psi.Cache
 {
 	public interface IT4FileGraphNotifier
 	{
-		event Action<IEnumerable<FileSystemPath>> OnFilesIndirectlyAffected;
+		event Action<IEnumerable<IPsiSourceFile>> OnFilesIndirectlyAffected;
 	}
 }

--- a/Backend/ForTea.Core/Psi/Cache/IT4PsiFileSelector.cs
+++ b/Backend/ForTea.Core/Psi/Cache/IT4PsiFileSelector.cs
@@ -1,0 +1,14 @@
+using JetBrains.Annotations;
+using JetBrains.ReSharper.Psi;
+using JetBrains.Util;
+
+namespace GammaJul.ForTea.Core.Psi.Cache
+{
+	public interface IT4PsiFileSelector
+	{
+		IPsiSourceFile FindMostSuitableFile(
+			[NotNull] FileSystemPath path,
+			[NotNull] IPsiSourceFile requester
+		);
+	}
+}

--- a/Backend/ForTea.Core/Psi/Cache/Impl/T4FileDependencyCache.cs
+++ b/Backend/ForTea.Core/Psi/Cache/Impl/T4FileDependencyCache.cs
@@ -2,10 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using GammaJul.ForTea.Core.Tree;
-using GammaJul.ForTea.Core.Utils;
 using JetBrains.Annotations;
+using JetBrains.Diagnostics;
 using JetBrains.Lifetimes;
-using JetBrains.ProjectModel;
 using JetBrains.ReSharper.Psi;
 using JetBrains.ReSharper.Psi.Caches;
 using JetBrains.Util;
@@ -18,69 +17,82 @@ namespace GammaJul.ForTea.Core.Psi.Cache.Impl
 	/// this cache marks all the former dependencies and all the new dependencies as dirty.
 	/// </summary>
 	[PsiComponent]
-	public sealed class T4FileDependencyCache : T4PsiAwareCacheBase<T4FileDependencyData, T4FileDependencyData>,
+	public sealed class T4FileDependencyCache : T4PsiAwareCacheBase<T4IncludeData, T4FileDependencyData>,
 		IT4FileDependencyGraph, IT4FileGraphNotifier
 	{
-		public event Action<IEnumerable<FileSystemPath>> OnFilesIndirectlyAffected;
+		[NotNull]
+		private T4GraphSinkSearcher GraphSinkSearcher { get; }
 
 		[NotNull]
-		private IDictionary<FileSystemPath, T4FileDependencyData> IncluderToIncludes =>
-			Map.Distinct(it => it.Key.GetLocation()).ToDictionary(it => it.Key.GetLocation(), it => it.Value);
+		private T4IndirectIncludeTransitiveClosureSearcher TransitiveClosureSearcher { get; }
 
 		[NotNull]
-		private IDictionary<FileSystemPath, T4FileDependencyData> IncludeToIncluders
-		{
-			get
-			{
-				var includerToIncludes = IncluderToIncludes;
-				return includerToIncludes
-					.Keys
-					.Concat(Map.SelectMany(it => it.Value.Paths))
-					.Distinct().ToDictionary(
-						file => file,
-						file => new T4FileDependencyData(includerToIncludes
-							.Where(entry => entry.Value.Paths.Contains(file))
-							.Select(entry => entry.Key).AsList()
-						)
-					);
-			}
-		}
+		private IT4PsiFileSelector PsiFileSelector { get; }
+
+		public event Action<IEnumerable<IPsiSourceFile>> OnFilesIndirectlyAffected;
+
+		[CanBeNull]
+		private T4FileDependencyData TryGetIncludes([NotNull] IPsiSourceFile file) => Map.TryGetValue(file);
 
 		public T4FileDependencyCache(
 			Lifetime lifetime,
-			[NotNull] IPersistentIndexManager persistentIndexManager
+			[NotNull] IPersistentIndexManager persistentIndexManager,
+			[NotNull] T4GraphSinkSearcher graphSinkSearcher,
+			[NotNull] T4IndirectIncludeTransitiveClosureSearcher transitiveClosureSearcher,
+			[NotNull] IT4PsiFileSelector psiFileSelector
 		) : base(lifetime, persistentIndexManager, T4FileDependencyDataMarshaller.Instance)
 		{
+			GraphSinkSearcher = graphSinkSearcher;
+			TransitiveClosureSearcher = transitiveClosureSearcher;
+			PsiFileSelector = psiFileSelector;
 		}
 
-		public IProjectFile FindBestRoot(IProjectFile file) =>
-			FindBestRoot(file.Location).FindMostSuitableFile(file);
-
-		[NotNull]
-		private FileSystemPath FindBestRoot([NotNull] FileSystemPath include) =>
-			new T4GraphSinkSearcher(IncludeToIncluders).FindClosestSink(include);
+		public IPsiSourceFile FindBestRoot(IPsiSourceFile include) =>
+			GraphSinkSearcher.FindClosestSink(TryGetIncludes, include);
 
 		[NotNull, ItemNotNull]
-		private IEnumerable<FileSystemPath> FindIndirectIncludesTransitiveClosure([NotNull] FileSystemPath path) =>
-			new T4IndirectIncludeTransitiveClosureSearcher(IncluderToIncludes, IncludeToIncluders).FindClosure(path);
+		private IEnumerable<IPsiSourceFile> FindIndirectIncludesTransitiveClosure([NotNull] IPsiSourceFile file) =>
+			TransitiveClosureSearcher.FindClosure(TryGetIncludes, file);
 
-		protected override T4FileDependencyData Build(IT4File file)
-		{
-			var includes = file
-				.GetThisAndChildrenOfType<IT4IncludeDirective>()
-				.Where(directive => directive.IsVisibleInDocument())
-				.Select(directive => directive.Path.ResolvePath())
-				.Where(path => !path.IsEmpty)
-				.Distinct();
-			return new T4FileDependencyData(includes.ToList());
-		}
+		protected override T4IncludeData Build(IT4File file) => new T4IncludeData(file
+			.BlocksEnumerable
+			.OfType<IT4IncludeDirective>()
+			.Select(directive => directive.Path.ResolvePath())
+			.Where(path => !path.IsEmpty)
+			.Distinct()
+			.ToList()
+		);
 
 		public override void Merge(IPsiSourceFile sourceFile, object builtPart)
 		{
-			var oldIncludes = FindIndirectIncludesTransitiveClosure(sourceFile.GetLocation());
-			base.Merge(sourceFile, builtPart);
-			var newIncludes = FindIndirectIncludesTransitiveClosure(sourceFile.GetLocation());
-			OnFilesIndirectlyAffected?.Invoke(oldIncludes.Concat(newIncludes));
+			var data = (T4IncludeData) builtPart.NotNull();
+			var includes = data.Includes;
+			var includers = Map.TryGetValue(sourceFile)?.Includers ?? new List<FileSystemPath>();
+			var oldIncludes = FindIndirectIncludesTransitiveClosure(sourceFile);
+			base.Merge(sourceFile, new T4FileDependencyData(includes, includers));
+			var newIncludes = FindIndirectIncludesTransitiveClosure(sourceFile);
+			OnFilesIndirectlyAffected?.Invoke(oldIncludes.Union(newIncludes));
+			UpdateIncluders(sourceFile, includes);
+		}
+
+		private void UpdateIncluders([NotNull] IPsiSourceFile sourceFile, [NotNull] IList<FileSystemPath> includes)
+		{
+			foreach (var include in includes)
+			{
+				var includedSourceFile = PsiFileSelector.FindMostSuitableFile(include, sourceFile);
+				var existingData = Map.TryGetValue(includedSourceFile);
+				if (existingData == null)
+				{
+					var includers = new List<FileSystemPath> {sourceFile.GetLocation()};
+					Map[includedSourceFile] = new T4FileDependencyData(EmptyList<FileSystemPath>.Instance, includers);
+				}
+				else
+				{
+					var includers = existingData.Includers;
+					includers.Add(sourceFile.GetLocation());
+					Map[includedSourceFile] = new T4FileDependencyData(existingData.Includes, includers);
+				}
+			}
 		}
 	}
 }

--- a/Backend/ForTea.Core/Psi/Cache/Impl/T4FileDependencyData.cs
+++ b/Backend/ForTea.Core/Psi/Cache/Impl/T4FileDependencyData.cs
@@ -7,8 +7,18 @@ namespace GammaJul.ForTea.Core.Psi.Cache.Impl
 	public sealed class T4FileDependencyData
 	{
 		[NotNull, ItemNotNull]
-		public IList<FileSystemPath> Paths { get; }
+		public IList<FileSystemPath> Includes { get; }
 
-		public T4FileDependencyData([NotNull, ItemNotNull] IList<FileSystemPath> includes) => Paths = includes;
+		[NotNull]
+		public IList<FileSystemPath> Includers { get; }
+
+		public T4FileDependencyData(
+			[NotNull, ItemNotNull] IList<FileSystemPath> includes,
+			[NotNull] IList<FileSystemPath> includers
+		)
+		{
+			Includes = includes;
+			Includers = includers;
+		}
 	}
 }

--- a/Backend/ForTea.Core/Psi/Cache/Impl/T4FileDependencyDataMarshaller.cs
+++ b/Backend/ForTea.Core/Psi/Cache/Impl/T4FileDependencyDataMarshaller.cs
@@ -21,11 +21,18 @@ namespace GammaJul.ForTea.Core.Psi.Cache.Impl
 		[NotNull]
 		public static T4FileDependencyDataMarshaller Instance { get; } = new T4FileDependencyDataMarshaller();
 
-		public void Marshal([NotNull] UnsafeWriter writer, [NotNull] T4FileDependencyData value) =>
-			PathListMarshaller.Marshal(writer, value.Paths);
+		public void Marshal([NotNull] UnsafeWriter writer, [NotNull] T4FileDependencyData value)
+		{
+			PathListMarshaller.Marshal(writer, value.Includes);
+			PathListMarshaller.Marshal(writer, value.Includers);
+		}
 
 		[NotNull]
-		public T4FileDependencyData Unmarshal([NotNull] UnsafeReader reader) =>
-			new T4FileDependencyData(PathListMarshaller.Unmarshal(reader));
+		public T4FileDependencyData Unmarshal([NotNull] UnsafeReader reader)
+		{
+			var includes = PathListMarshaller.Unmarshal(reader);
+			var includers = PathListMarshaller.Unmarshal(reader);
+			return new T4FileDependencyData(includes, includers);
+		}
 	}
 }

--- a/Backend/ForTea.Core/Psi/Cache/Impl/T4IncludeData.cs
+++ b/Backend/ForTea.Core/Psi/Cache/Impl/T4IncludeData.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using JetBrains.Util;
+
+namespace GammaJul.ForTea.Core.Psi.Cache.Impl
+{
+	public sealed class T4IncludeData
+	{
+		[NotNull, ItemNotNull]
+		public IList<FileSystemPath> Includes { get; }
+
+		public T4IncludeData([NotNull, ItemNotNull] IList<FileSystemPath> includes) => Includes = includes;
+	}
+}

--- a/Backend/ForTea.Core/Psi/Cache/Impl/T4PsiFileSelector.cs
+++ b/Backend/ForTea.Core/Psi/Cache/Impl/T4PsiFileSelector.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Linq;
+using GammaJul.ForTea.Core.Psi.OutsideSolution;
+using JetBrains.Annotations;
+using JetBrains.ProjectModel;
+using JetBrains.ReSharper.Psi;
+using JetBrains.Util;
+
+namespace GammaJul.ForTea.Core.Psi.Cache.Impl
+{
+	[SolutionComponent]
+	public sealed class T4PsiFileSelector : IT4PsiFileSelector
+	{
+		[NotNull]
+		private T4OutsideSolutionSourceFileManager OutsideSolutionManager { get; }
+
+		public T4PsiFileSelector([NotNull] T4OutsideSolutionSourceFileManager outsideSolutionManager) =>
+			OutsideSolutionManager = outsideSolutionManager;
+
+		[CanBeNull]
+		public IPsiSourceFile FindMostSuitableFile(FileSystemPath path, IPsiSourceFile requester)
+		{
+			var psf = PsiSourceFile(path, requester);
+			if (psf != null) return psf;
+			if (path.ExistsFile) return OutsideSolutionManager.GetOrCreateSourceFile(path);
+			return null;
+		}
+
+		[CanBeNull]
+		private static IPsiSourceFile PsiSourceFile([NotNull] FileSystemPath path, [NotNull] IPsiSourceFile requester)
+		{
+			if (path.IsEmpty) return null;
+			var potentialProjectFiles = requester
+				.GetSolution()
+				.FindProjectItemsByLocation(path)
+				.OfType<IProjectFile>()
+				.AsList();
+			var projectFile = SelectMostPlausibleT4ProjectFile(potentialProjectFiles, requester);
+			if (projectFile == null) return null;
+			return FindMostSuitableFile(projectFile, requester);
+		}
+
+		[CanBeNull]
+		private static IProjectFile SelectMostPlausibleT4ProjectFile(
+			[NotNull, ItemNotNull] IList<IProjectFile> files,
+			[NotNull] IPsiSourceFile requester
+		)
+		{
+			var targetFrameworkId = requester.PsiModule.TargetFrameworkId;
+			var correctBuildActionItem = files
+				.FirstOrDefault(file => file.Properties.GetBuildAction(targetFrameworkId) == BuildAction.NONE);
+			return correctBuildActionItem ?? files.FirstOrDefault();
+		}
+
+		[CanBeNull]
+		private static IPsiSourceFile FindMostSuitableFile(
+			[NotNull] IProjectFile projectFile,
+			[NotNull] IPsiSourceFile requester
+		)
+		{
+			var sourceFiles = projectFile.ToSourceFiles();
+			var targetFrameworkId = requester.PsiModule.TargetFrameworkId;
+			var correctTargetFrameworkItem = sourceFiles
+				.FirstOrDefault<object>(null, (_, file) => file.PsiModule.TargetFrameworkId == targetFrameworkId);
+			return correctTargetFrameworkItem ?? sourceFiles.FirstOrDefault();
+		}
+	}
+}

--- a/Backend/ForTea.Core/Psi/Cache/T4PsiAwareCacheBase.cs
+++ b/Backend/ForTea.Core/Psi/Cache/T4PsiAwareCacheBase.cs
@@ -14,7 +14,7 @@ namespace GammaJul.ForTea.Core.Psi.Cache
 	public abstract class T4PsiAwareCacheBase<TRequest, TResponse> : SimpleICache<TResponse> where TRequest : class
 	{
 		[NotNull]
-		public override string Version => "2";
+		public override string Version => "5";
 
 
 		protected T4PsiAwareCacheBase(


### PR DESCRIPTION
The cache (aka the include graph) used to only store paths to all of the included files. However, an extremely common operation is finding all the files that include a file, i.e. the reverse graph. The reverse graph used to be built every time it was required, which caused [significant performance issues](https://youtrack.jetbrains.com/issue/RIDER-42504). This cache now stores and maintains both includers and includees.

Note: this PR only includes meaningful changes; the ones I did not deem meaningful can be found [here](https://github.com/JetBrains/ForTea/commit/579f9ceee83d192a4af8e067174b7e905a91ae10)